### PR TITLE
stopplacecode en stopplaceref verplicht gemaakt binnen quay element

### DIFF
--- a/xsd/passengerstopassignment.xsd
+++ b/xsd/passengerstopassignment.xsd
@@ -11,72 +11,73 @@
 <!--       8.1.0 (okt.2022): toevoegen StopPlaces (tbv stations) en QuayRef en StopPlaceRef  -->
 <!--       8.2.0 (sep.2023): toevoegen StopPlaceCode en StopPlaceRef (verplicht) bij Quay    -->
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified" version="8.2.0">
- <xs:element name="dataownercode" type="xs:string"/>
- <xs:element name="userstopcode" type="xs:string"/>
- <xs:element name="validfrom" type="xs:string"/>
- <xs:element name="validthru" type="xs:string"/>
- <xs:element name="userstopcodedata">
-  <xs:complexType>
-   <xs:sequence>
-    <xs:element ref="dataownercode"/>
-    <xs:element ref="userstopcode"/>
-    <xs:element ref="validfrom"/>
-    <xs:element ref="validthru" minOccurs="0"/>
-   </xs:sequence>
-  </xs:complexType>
- </xs:element>
- <xs:element name="quaycode" type="xs:string"/>
- <xs:element name="quayref" type="xs:string"/>
- <xs:element name="stopplacecode" type="xs:string"/>
- <xs:element name="stopplaceref" type="xs:string"/>
- <xs:element name="userstopcodes">
-  <xs:complexType>
-   <xs:sequence>
-    <xs:element ref="userstopcodedata" minOccurs="1" maxOccurs="unbounded"/>
-   </xs:sequence>
-  </xs:complexType>
- </xs:element>
- <xs:element name="quay">
-  <xs:complexType>
-   <xs:sequence>
-    <xs:element ref="quaycode"/>
-    <xs:element ref="quayref"/>    
-	<xs:element ref="stopplacecode"/>
-    <xs:element ref="stopplaceref"/>    
-    <xs:element ref="userstopcodes"/>
-   </xs:sequence>
-  </xs:complexType>
- </xs:element>
- <xs:element name="quays">
-  <xs:complexType>
-   <xs:sequence>
-    <xs:element ref="quay" minOccurs="1" maxOccurs="unbounded"/>
-   </xs:sequence>
-  </xs:complexType>
- </xs:element>
-  <xs:element name="stopplace">
-  <xs:complexType>
-   <xs:sequence>
-    <xs:element ref="stopplacecode"/>
-    <xs:element ref="stopplaceref"/>    
-    <xs:element ref="userstopcodes"/>
-   </xs:sequence>
-  </xs:complexType>
- </xs:element>
- <xs:element name="stopplaces">
-  <xs:complexType>
-   <xs:sequence>
-    <xs:element ref="stopplace" minOccurs="0" maxOccurs="unbounded"/>
-   </xs:sequence>
-  </xs:complexType>
- </xs:element>
- <xs:element name="export">
-  <xs:complexType>
-   <xs:sequence>
-    <xs:element ref="quays"/>
-    <xs:element ref="stopplaces"/>
-   </xs:sequence>
-  </xs:complexType>
- </xs:element>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified"
+           version="8.2.0">
+    <xs:element name="dataownercode" type="xs:string"/>
+    <xs:element name="userstopcode" type="xs:string"/>
+    <xs:element name="validfrom" type="xs:string"/>
+    <xs:element name="validthru" type="xs:string"/>
+    <xs:element name="userstopcodedata">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="dataownercode"/>
+                <xs:element ref="userstopcode"/>
+                <xs:element ref="validfrom"/>
+                <xs:element ref="validthru" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quaycode" type="xs:string"/>
+    <xs:element name="quayref" type="xs:string"/>
+    <xs:element name="stopplacecode" type="xs:string"/>
+    <xs:element name="stopplaceref" type="xs:string"/>
+    <xs:element name="userstopcodes">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="userstopcodedata" minOccurs="1" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quay">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="quaycode"/>
+                <xs:element ref="quayref"/>
+                <xs:element ref="stopplacecode"/>
+                <xs:element ref="stopplaceref"/>
+                <xs:element ref="userstopcodes"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="quays">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="quay" minOccurs="1" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="stopplace">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="stopplacecode"/>
+                <xs:element ref="stopplaceref"/>
+                <xs:element ref="userstopcodes"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="stopplaces">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="stopplace" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="export">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="quays"/>
+                <xs:element ref="stopplaces"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
 </xs:schema>

--- a/xsd/passengerstopassignment.xsd
+++ b/xsd/passengerstopassignment.xsd
@@ -9,8 +9,9 @@
 <!--       8.0.0 (okt.2015): Initiële versie                                                 -->
 <!--       8.0.1 (jun.2020): Optionele validthru toegevoegd aan userstopcodedata             -->
 <!--       8.1.0 (okt.2022): toevoegen StopPlaces (tbv stations) en QuayRef en StopPlaceRef  -->
+<!--       8.2.0 (sep.2023): toevoegen StopPlaceCode en StopPlaceRef (verplicht) bij Quay    -->
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified" version="8.0.1">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified" version="8.2.0">
  <xs:element name="dataownercode" type="xs:string"/>
  <xs:element name="userstopcode" type="xs:string"/>
  <xs:element name="validfrom" type="xs:string"/>

--- a/xsd/passengerstopassignment.xsd
+++ b/xsd/passengerstopassignment.xsd
@@ -26,10 +26,10 @@
   </xs:complexType>
  </xs:element>
  <xs:element name="quaycode" type="xs:string"/>
-  <xs:element name="quayref" type="xs:string"/>
+ <xs:element name="quayref" type="xs:string"/>
  <xs:element name="stopplacecode" type="xs:string"/>
  <xs:element name="stopplaceref" type="xs:string"/>
-<xs:element name="userstopcodes">
+ <xs:element name="userstopcodes">
   <xs:complexType>
    <xs:sequence>
     <xs:element ref="userstopcodedata" minOccurs="1" maxOccurs="unbounded"/>
@@ -41,6 +41,8 @@
    <xs:sequence>
     <xs:element ref="quaycode"/>
     <xs:element ref="quayref"/>    
+	<xs:element ref="stopplacecode"/>
+    <xs:element ref="stopplaceref"/>    
     <xs:element ref="userstopcodes"/>
    </xs:sequence>
   </xs:complexType>


### PR DESCRIPTION
Om de overgang naar PSA in NeTEx (ipv PSA in CHB) zo soepel mogelijk te laten verlopen is de stopplacecode en stopplaceref toegevoegd en verplicht gemaakt binnen een quay element. Op deze manier trekken we ook de XML export van de CHB PSA gelijk met bijbehorende documentatie, als ook met de CSV export. 